### PR TITLE
use library(sf) in vignette

### DIFF
--- a/vignettes/recreating_analyses.Rmd
+++ b/vignettes/recreating_analyses.Rmd
@@ -20,6 +20,7 @@ library(ggplot2)
 library(knitr)
 library(tidyr)
 library(salem)
+library(sf)
 ```
 
 The [Salem Witchcraft Website](https://www.tulane.edu/~salem/index.html)
@@ -345,34 +346,23 @@ newdata$TOWN_LABEL <- ifelse(newdata$n_accused == 0, NA,  newdata$TOWN_LABEL)
 ```
 
 ```{r fig.width=8, fig.height=8}
-if (requireNamespace("sf", quietly = TRUE)) {
-      p1 <- ggplot(newdata) 
-      p2 <- geom_sf_text(aes(label = TOWN_LABEL), color = "blue", size = 2, nudge_x = 5,
-                      nudge_y = 5, na.rm = TRUE) 
-      p3 <-       scale_fill_manual(values = c( "grey", "red"), na.value = "white") 
-}
-if (requireNamespace("sf", quietly = TRUE)) {
-      p1  + geom_sf(data = newdata,  aes(fill = February.Any), color = "black", size = .1) +
-        p3 + p2 + labs(title = "Location of Accusations in February") 
-}
-if (requireNamespace("sf", quietly = TRUE)) {
-      p1 +  geom_sf(data = newdata,  aes(fill = July.Any), color = "black", size = .1) +
-        p3 + p2 + labs(title = "Location of Accusations in July") 
-}     
- if (requireNamespace("sf", quietly = TRUE)) {     
-      p1 + geom_sf(data = newdata,  aes(fill = August.Any), color = "black", size = .1) +
-        p3 + p2  + labs(title = "Location of Accusations in August") 
- }
-if (requireNamespace("sf", quietly = TRUE)) {
-      p1 + geom_sf(data = newdata,  aes(fill = November.Any), color = "black", size = .1) +
-        p3 + p2 + labs(title = "Location of Accusations in November") 
-}
+p1 <- ggplot(newdata) 
+p2 <- geom_sf_text(aes(label = TOWN_LABEL), color = "blue", size = 2, nudge_x = 5,
+                nudge_y = 5, na.rm = TRUE) 
+p3 <-       scale_fill_manual(values = c( "grey", "red"), na.value = "white") 
+
+p1  + geom_sf(data = newdata,  aes(fill = February.Any), color = "black", size = .1) +
+  p3 + p2 + labs(title = "Location of Accusations in February") 
+
+p1 +  geom_sf(data = newdata,  aes(fill = July.Any), color = "black", size = .1) +
+  p3 + p2 + labs(title = "Location of Accusations in July") 
+
+p1 + geom_sf(data = newdata,  aes(fill = August.Any), color = "black", size = .1) +
+  p3 + p2  + labs(title = "Location of Accusations in August") 
+
+p1 + geom_sf(data = newdata,  aes(fill = November.Any), color = "black", size = .1) +
+  p3 + p2 + labs(title = "Location of Accusations in November") 
 ```
-
-
-
-
-
 
 
 ## Social Conflict


### PR DESCRIPTION
As part of testing reserve dependencies of the upcoming dplyr 1.0.8 (released soon), we've identified a potential issue with the vignette of this package. The tests give: 

````
# salem

<details>

* Version: 0.2.0
* GitHub: NA
* Source code: https://github.com/cran/salem
* Date/Publication: 2020-11-05 16:40:05 UTC
* Number of recursive dependencies: 62

Run `cloud_details(, "salem")` for more info

</details>

## Newly broken

*   checking re-building of vignette outputs ... WARNING
    ```
    Error(s) in re-building vignettes:
      ...
    --- re-building ‘introduction.Rmd’ using rmarkdown
    --- finished re-building ‘introduction.Rmd’
    
    --- re-building ‘recreating_analyses.Rmd’ using rmarkdown
    Joining, by = "Month"
    Quitting from lines 348-367 (recreating_analyses.Rmd) 
    Error: processing vignette 'recreating_analyses.Rmd' failed with diagnostics:
    Can't convert NULL to a symbol.
    --- failed re-building ‘recreating_analyses.Rmd’
    
    SUMMARY: processing the following file failed:
      ‘recreating_analyses.Rmd’
    
    Error: Vignette re-building failed.
    Execution halted
    ```
````

Loading sf with `library(sf)` seems to be fixing it. I suppose this is something about method registration that is not done the same way with `requireNamespace()` 